### PR TITLE
BUGFIX: Prevent unexpected token errors with various loaders

### DIFF
--- a/src/uFuzzy.js
+++ b/src/uFuzzy.js
@@ -662,7 +662,7 @@ export default function uFuzzy(opts) {
 
 				for (let ti = 0; ti < terms2.length; ti++) {
 					// no haystack item contained all terms
-					if (preFiltered?.length == 0)
+					if (preFiltered && preFiltered.length == 0)
 						return [[], null, null];
 
 					preFiltered = filter(haystack, terms2[ti], preFiltered);
@@ -700,7 +700,7 @@ export default function uFuzzy(opts) {
 		// non-ooo or ooo w/single term
 		if (needles == null) {
 			needles = [needle];
-			matches = [preFiltered?.length > 0 ? preFiltered : filter(haystack, needle)];
+			matches = [preFiltered && preFiltered.length > 0 ? preFiltered : filter(haystack, needle)];
 		}
 
 		let retInfo = null;


### PR DESCRIPTION
When I try to include the library in a web pack build I get the following error due to the optional chaining character:

```
Module parse failed: Unexpected token (666:21)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|                               for (let ti = 0; ti < terms2.length; ti++) {
|                                       // no haystack item contained all terms
>                                       if (preFiltered?.length == 0)
```