### PR TITLE
Remove default parameter values from type declaration file

### DIFF
--- a/dist/uFuzzy.d.ts
+++ b/dist/uFuzzy.d.ts
@@ -5,7 +5,7 @@ declare class uFuzzy {
 	search(
 		haystack: string[],
 		needle: string,
-		/** False by default */
+		/** false by default */
 		outOfOrder?: boolean,
 		/** 1e3 by default */
 		infoThresh?: number,

--- a/dist/uFuzzy.d.ts
+++ b/dist/uFuzzy.d.ts
@@ -5,7 +5,9 @@ declare class uFuzzy {
 	search(
 		haystack: string[],
 		needle: string,
+		/** False by default */
 		outOfOrder?: boolean,
+		/** 1e3 by default */
 		infoThresh?: number,
 		preFiltered?: uFuzzy.HaystackIdxs | null
 	): uFuzzy.SearchResult;

--- a/dist/uFuzzy.d.ts
+++ b/dist/uFuzzy.d.ts
@@ -5,8 +5,8 @@ declare class uFuzzy {
 	search(
 		haystack: string[],
 		needle: string,
-		outOfOrder = false,
-		infoThresh = 1e3,
+		outOfOrder?: boolean,
+		infoThresh?: number,
 		preFiltered?: uFuzzy.HaystackIdxs | null
 	): uFuzzy.SearchResult;
 


### PR DESCRIPTION
I have some type errors coming from the type declaration file of this library when I check the types in my project:

```
 uFuzzy % tsc --noEmit dist/uFuzzy.d.ts
dist/uFuzzy.d.ts:8:3 - error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
                                                                                                
8   outOfOrder = false,  
    ~~~~~~~~~~~~~~~~~~                                                                          
                                                
dist/uFuzzy.d.ts:9:3 - error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
                                                
9   infoThresh = 1e3,                 
    ~~~~~~~~~~~~~~~~
                                                
                                                
Found 2 errors in the same file, starting at: dist/uFuzzy.d.ts:8
```

The problem is that there are default parameter values in a type declaration, which doesn't exist at runtime. In this PR I just removed them and made the parameters optional, which should be equivalent.