### PR TITLE
Fix Node.js ESM/CJS interoperability

### DIFF
--- a/dist/uFuzzy.cjs
+++ b/dist/uFuzzy.cjs
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2024, Leon Sorokin
+* Copyright (c) 2025, Leon Sorokin
 * All rights reserved. (MIT Licensed)
 *
 * uFuzzy.js (μFuzzy)

--- a/dist/uFuzzy.iife.js
+++ b/dist/uFuzzy.iife.js
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2024, Leon Sorokin
+* Copyright (c) 2025, Leon Sorokin
 * All rights reserved. (MIT Licensed)
 *
 * uFuzzy.js (μFuzzy)

--- a/dist/uFuzzy.mjs
+++ b/dist/uFuzzy.mjs
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2024, Leon Sorokin
+* Copyright (c) 2025, Leon Sorokin
 * All rights reserved. (MIT Licensed)
 *
 * uFuzzy.js (μFuzzy)

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@leeoniya/ufuzzy",
   "version": "1.0.17",
   "description": "A tiny, efficient fuzzy matcher that doesn't suck",
-  "main": "./dist/uFuzzy.cjs.js",
-  "module": "./dist/uFuzzy.esm.js",
+  "main": "./dist/uFuzzy.cjs",
+  "module": "./dist/uFuzzy.mjs",
   "types": "./dist/uFuzzy.d.ts",
   "type": "module",
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,7 +27,7 @@ function bannerlessESM() {
 		},
 		load(id) {
 			if (id == 'uFuzzy')
-				return fs.readFileSync('./dist/uFuzzy.esm.js', 'utf8').replace(/\/\*\*.*?\*\//gms, '');
+				return fs.readFileSync('./dist/uFuzzy.mjs', 'utf8').replace(/\/\*\*.*?\*\//gms, '');
 			return null;
 		}
 	};
@@ -54,7 +54,7 @@ export default [
 		input: './src/uFuzzy.mjs',
 		output: {
 			name: 'uFuzzy',
-			file: './dist/uFuzzy.esm.js',
+			file: './dist/uFuzzy.mjs',
 			format: 'es',
 			banner,
 		},
@@ -63,7 +63,7 @@ export default [
 		input: './src/uFuzzy.mjs',
 		output: {
 			name: 'uFuzzy',
-			file: './dist/uFuzzy.cjs.js',
+			file: './dist/uFuzzy.cjs',
 			format: 'cjs',
 			exports: "auto",
 			banner,


### PR DESCRIPTION
This fixes the folloing error in a TypeScript project with a `tsconfig.json` like 

```json
{
  "compilerOptions": {
    "target": "ES2020",
    "module": "commonjs",
    "moduleResolution": "node",
    "lib": ["ES2020"]
}

```

for me:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module .../node_modules/@leeoniya/ufuzzy/dist/uFuzzy.cjs.js from ... not supported.
uFuzzy.cjs.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead either rename uFuzzy.cjs.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in .../node_modules/@leeoniya/ufuzzy/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).
```

by using correct file extensions for CJS and ESM files so that Node.js can properly detect them.

I has also tested different `tsconfig.json` settings but they more or less all failed with a similar error.